### PR TITLE
Rename default branch references from master to main

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,10 +1,10 @@
 name: release
 
 on:
-  # Trigger analysis when pushing in master
+  # Trigger analysis when pushing in main
   push:
     branches:
-      - master
+      - main
 
 jobs:
   release:

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ dependencies {
 
 ## How to release
 
-A release is automatically triggered after each merge to the master branch. Your new version will appear after some time in [repo1.maven.org/.../j8583/](https://repo1.maven.org/maven2/io/github/thibaudledent/j8583/j8583/) (and a bit later in: [search.maven.org/artifact/.../j8583](https://search.maven.org/artifact/io.github.thibaudledent.j8583/j8583)).
+A release is automatically triggered after each merge to the main branch. Your new version will appear after some time in [repo1.maven.org/.../j8583/](https://repo1.maven.org/maven2/io/github/thibaudledent/j8583/j8583/) (and a bit later in: [search.maven.org/artifact/.../j8583](https://search.maven.org/artifact/io.github.thibaudledent.j8583/j8583)).
 
-More info about the release [here](https://github.com/thibaudledent/j8583/blob/master/RELEASE.md).
+More info about the release [here](https://github.com/thibaudledent/j8583/blob/main/RELEASE.md).
 
 ## How to contribute
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,14 +1,14 @@
 # About the release
 
-A release is automatically triggered after each merge to the master branch.
+A release is automatically triggered after each merge to the main branch.
 
 ## Manual release
 
 To force a release a new version of the library to Maven Central:
 
-1) Increment the [version](https://github.com/thibaudledent/j8583/blob/master/pom.xml#L7) of the library in the main `pom.xml`  and create a Pull Request
+1) Increment the [version](https://github.com/thibaudledent/j8583/blob/main/pom.xml#L7) of the library in the main `pom.xml`  and create a Pull Request
 
-2) Merge the Pull Request to the master branch
+2) Merge the Pull Request to the main branch
 
 3) Run the [manual-release](https://github.com/thibaudledent/j8583/actions/workflows/manual-release.yaml) workflow (see also [Manually running a workflow](https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow))
 

--- a/release.sh
+++ b/release.sh
@@ -40,7 +40,7 @@ echo "The release version is $RELEASE_VERSION"
 NEXT_DEV_VERSION=$(echo "$RELEASE_VERSION" | awk '{split($1,a,"."); print a[1] "." a[2] "."  a[3]+1 "-SNAPSHOT"}')
 echo "The next development version is $NEXT_DEV_VERSION"
 
-# Create a new branch to avoid the error: GH006: Protected branch update failed for refs/heads/master (At least 1 approving review is required by reviewers with write access)
+# Create a new branch to avoid the error: GH006: Protected branch update failed for refs/heads/main (At least 1 approving review is required by reviewers with write access)
 BRANCH_NAME=after-release-"$RELEASE_VERSION"-$RANDOM
 git checkout -b "$BRANCH_NAME"
 


### PR DESCRIPTION
Preparing to switch the repository's default branch on GitHub from master to main.