### PR TITLE
Fix release loop guard to work with squash-merged snapshot PRs

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -3,7 +3,7 @@ set -eEuxo pipefail
 
 git --no-pager log -n 1 --pretty=oneline
 
-if git --no-pager log -n 1 --pretty=oneline | grep -qE "Merge .*after-release-[0-9]+\.[0-9]+\.[0-9]+"; then
+if git --no-pager log -n 1 --pretty=oneline | grep -qE "after[- ]release-[0-9]+\.[0-9]+\.[0-9]+"; then
   echo "This pull request is a follow-up of a release and will not trigger a new one."
   exit 0
 fi


### PR DESCRIPTION
The guard only matched GitHub's merge-commit message format
("Merge ... after-release-X.Y.Z"). PR #168 was squash-merged, producing
"Update snapshot version after release-X.Y.Z (#168)" instead, which the
regex missed, so release.sh re-triggered a new release. The pattern now
matches the follow-up commit regardless of merge method.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01XqA8mRRtMD4vRqQPc4yaqK