### PR TITLE
Target Java 17 bytecode instead of Java 26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <maven.compiler.release>17</maven.compiler.release>
         <skipRelease>true</skipRelease>
         <skipDepCheck>true</skipDepCheck>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
@@ -94,10 +95,6 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.15.0</version>
-                <configuration>
-                    <source>26</source>
-                    <target>26</target>
-                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
@@ -133,7 +130,7 @@
                 <configuration>
                     <skip>${skipRelease}</skip>
                     <links>
-                        <link>https://docs.oracle.com/en/java/javase/26/docs/api/</link>
+                        <link>https://docs.oracle.com/en/java/javase/17/docs/api/</link>
                         <link>http://slf4j.org/apidocs/</link>
                     </links>
                 </configuration>


### PR DESCRIPTION
The library used no Java 18-26 language features or APIs, so
compiling to target 26 only narrowed the compatible JRE range with
no benefit. maven.compiler.release=17 restores compatibility with
Java 17+ consumers while still allowing the project to be built with
newer JDKs.