### PR TITLE
Bump snapshot version after release-1.26.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ Maven:
 <dependency>
   <groupId>io.github.thibaudledent.j8583</groupId>
   <artifactId>j8583</artifactId>
-  <version>1.26.0</version>
+  <version>1.26.1</version>
 </dependency>
 ```
 
 Gradle:
 ```gradle
 dependencies {
-  implementation 'io.github.thibaudledent.j8583:j8583:1.26.0'
+  implementation 'io.github.thibaudledent.j8583:j8583:1.26.1'
 }
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>io.github.thibaudledent.j8583</groupId>
     <artifactId>j8583</artifactId>
-    <version>1.26.1-SNAPSHOT</version>
+    <version>1.26.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>j8583</name>
 


### PR DESCRIPTION
PR #169 (the automated post-release snapshot-version-bump PR) was
closed without merging, so main stayed on 1.26.1-SNAPSHOT even though
the j8583-1.26.1 tag and Maven Central release already exist. Every
subsequent push to main re-triggered the release workflow, which tried
to run `mvn release:prepare` for 1.26.1 again and failed with
"fatal: tag 'j8583-1.26.1' already exists".

Bump pom.xml to 1.26.2-SNAPSHOT and update the README version
references to the already-released 1.26.1, matching what the closed
PR would have done.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01SUYvB7MqVDP5pgQ8cUb44S