### PR TITLE
Stop leaking raw message content on unknown-type parse errors; add masked debugString()

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Build, analyze and test
-        run: mvn -V -B org.jacoco:jacoco-maven-plugin:prepare-agent verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -V -B -Pcoverage org.jacoco:jacoco-maven-plugin:prepare-agent verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
                # -V triggers an output of the Maven and Java versions at the beginning of the build
                # -B batch mode makes Maven less verbose
                # -DskipDepCheck skip OWASP dependency check during this phase

--- a/src/main/java/com/solab/iso8583/IsoMessage.java
+++ b/src/main/java/com/solab/iso8583/IsoMessage.java
@@ -100,6 +100,12 @@ public class IsoMessage {
 
     private static final char MASK_CHAR = '*';
 
+    /** Field numbers masked by the no-arg {@link #debugString()}. Empty by default so that
+     * method's behavior is unchanged unless explicitly configured, usually via
+     * {@link MessageFactory#setSensitiveFields(Set)} which propagates it to every message
+     * the factory creates or parses. */
+    private Set<Integer> sensitiveFields = Set.of();
+
     /** The message type. */
     private int type;
 
@@ -188,7 +194,32 @@ public class IsoMessage {
     }
 
     /**
-     * Sets the encoding to use.  
+     * Returns the field numbers masked by the no-arg {@link #debugString()}. Default is
+     * an empty set, meaning debugString() shows every field in clear text unless this
+     * is configured (usually via {@link MessageFactory#setSensitiveFields(Set)}).
+     *
+     * @return the sensitive fields
+     */
+    public Set<Integer> getSensitiveFields() {
+        return sensitiveFields;
+    }
+
+    /**
+     * Sets the field numbers to be masked by the no-arg {@link #debugString()}, instead
+     * of having to remember to pass them to {@link #debugString(Set)} on every call.
+     * {@link #COMMONLY_SENSITIVE_FIELDS} is a reasonable starting point.
+     *
+     * @param value the field numbers to mask
+     */
+    public void setSensitiveFields(Set<Integer> value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Cannot set null sensitiveFields.");
+        }
+        sensitiveFields = Set.copyOf(value);
+    }
+
+    /**
+     * Sets the encoding to use.
      *
      * @param value the value
      */
@@ -741,16 +772,18 @@ public class IsoMessage {
 
     /**
      * Returns a string representation of the message, as if it were encoded
-     * in ASCII with no binary bitmap. This includes the clear-text value of every field,
-     * which for real ISO8583 traffic commonly means cardholder data such as PANs, track
-     * data or PIN blocks. Avoid writing the result of this method to logs; use
-     * {@link #debugString(Set)} with a set of sensitive field numbers instead (see
-     * {@link #COMMONLY_SENSITIVE_FIELDS} for a reasonable starting point).
+     * in ASCII with no binary bitmap. Field values are shown in clear text, except for
+     * the field numbers configured via {@link #setSensitiveFields(Set)} (empty by
+     * default), which are masked. For real ISO8583 traffic this commonly means
+     * cardholder data such as PANs, track data or PIN blocks, so before logging the
+     * result make sure {@link #getSensitiveFields()} is configured appropriately (see
+     * {@link #COMMONLY_SENSITIVE_FIELDS} for a reasonable starting point), or call
+     * {@link #debugString(Set)} directly with an explicit set of fields to mask.
      *
      * @return the string
      */
     public String debugString() {
-        return debugString(Set.of());
+        return debugString(sensitiveFields);
     }
 
     /**

--- a/src/main/java/com/solab/iso8583/IsoMessage.java
+++ b/src/main/java/com/solab/iso8583/IsoMessage.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.BitSet;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Represents an ISO8583 message. This is the core class of the framework.
@@ -87,6 +88,17 @@ public class IsoMessage {
      * The Start of tertiary bitmap fields.
      */
     static final int START_OF_TERTIARY_BITMAP_FIELDS = END_OF_SECONDARY_BITMAP_FIELDS + 1;
+
+    /**
+     * Field numbers that commonly carry sensitive cardholder data (PAN, track 1/2/3 data,
+     * PIN block, ICC/EMV data) in typical ISO8583 implementations. This is a convenience
+     * default for {@link #debugString(Set)}; the exact field usage is defined by each
+     * institution's own message specification, so review and adjust this set for your
+     * own use case rather than relying on it blindly.
+     */
+    public static final Set<Integer> COMMONLY_SENSITIVE_FIELDS = Set.of(2, 34, 35, 36, 45, 52, 55);
+
+    private static final char MASK_CHAR = '*';
 
     /** The message type. */
     private int type;
@@ -729,10 +741,29 @@ public class IsoMessage {
 
     /**
      * Returns a string representation of the message, as if it were encoded
-     * in ASCII with no binary bitmap.  
+     * in ASCII with no binary bitmap. This includes the clear-text value of every field,
+     * which for real ISO8583 traffic commonly means cardholder data such as PANs, track
+     * data or PIN blocks. Avoid writing the result of this method to logs; use
+     * {@link #debugString(Set)} with a set of sensitive field numbers instead (see
+     * {@link #COMMONLY_SENSITIVE_FIELDS} for a reasonable starting point).
+     *
      * @return the string
      */
     public String debugString() {
+        return debugString(Set.of());
+    }
+
+    /**
+     * Returns a string representation of the message, as if it were encoded
+     * in ASCII with no binary bitmap, replacing the value of the specified fields
+     * with mask characters instead of showing them in clear text. The length header
+     * of variable-length fields, if any, still reflects the real (unmasked) length.
+     * Useful for logging/debugging without exposing sensitive cardholder data.
+     *
+     * @param maskedFields field numbers whose value should be masked instead of shown in clear text.
+     * @return the string
+     */
+    public String debugString(Set<Integer> maskedFields) {
         StringBuilder sb = new StringBuilder();
         if (isoHeader != null) {
             sb.append(isoHeader);
@@ -770,7 +801,11 @@ public class IsoMessage {
                 } else if (v.getType() == IsoType.LLLLBIN || v.getType() == IsoType.LLLLBCDBIN || v.getType() == IsoType.LLLLVAR || v.getType() == IsoType.LLLLBINLENGTHNUM || v.getType() == IsoType.LLLLBINLENGTHBIN || v.getType() == IsoType.LLLLBINLENGTHALPHANUM) {
                     sb.append(String.format("%04d", desc.length()));
                 }
-                sb.append(desc);
+                if (maskedFields.contains(i)) {
+                    sb.append(String.valueOf(MASK_CHAR).repeat(desc.length()));
+                } else {
+                    sb.append(desc);
+                }
             }
         }
         return sb.toString();

--- a/src/main/java/com/solab/iso8583/MessageFactory.java
+++ b/src/main/java/com/solab/iso8583/MessageFactory.java
@@ -674,12 +674,13 @@ public class MessageFactory<T extends IsoMessage> {
         Map<Integer, FieldParseInfo> parseGuide = parseMap.get(type);
         List<Integer> index = parseOrder.get(type);
         if (index == null) {
-            log.error(String.format("ISO8583 MessageFactory has no parsing guide for message type %04x [%s]",
-                    type, new String(buf)));
+            // Do not log or embed the raw message buffer here: it may contain sensitive
+            // cardholder data (PAN, track data, PIN blocks) and this is an error path that
+            // is more likely than most to end up in aggregated/centralized logs.
+            log.error("ISO8583 MessageFactory has no parsing guide for message type {} (buffer length {})",
+                    String.format("%04x", type), buf.length);
             throw new ParseException(String.format(
-                    "ISO8583 MessageFactory has no parsing guide for message type %04x [%s]",
-                    type,
-                    new String(buf)), 0);
+                    "ISO8583 MessageFactory has no parsing guide for message type %04x", type), 0);
         }
         //First we check if the message contains fields not specified in the parsing template
         assertAllFieldsPresentHaveParsingGuides(type, bs, index);

--- a/src/main/java/com/solab/iso8583/MessageFactory.java
+++ b/src/main/java/com/solab/iso8583/MessageFactory.java
@@ -21,6 +21,7 @@ package com.solab.iso8583;
 import com.solab.iso8583.parse.ConfigParser;
 import com.solab.iso8583.parse.DateTimeParseInfo;
 import com.solab.iso8583.parse.FieldParseInfo;
+import com.solab.iso8583.util.HexCodec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,6 +35,7 @@ import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TimeZone;
 
 import static com.solab.iso8583.IsoMessage.MAX_AMOUNT_OF_FIELDS;
@@ -116,6 +118,11 @@ public class MessageFactory<T extends IsoMessage> {
     /* Flag specifying that variable length fields have the length header encoded in hexadecimal format */
     private boolean variableLengthFieldsInHex;
     private String encoding = System.getProperty("file.encoding");
+    /** Field numbers propagated to every message created/parsed by this factory, to be
+     * masked by their no-arg {@link IsoMessage#debugString()}. Empty by default. */
+    private Set<Integer> sensitiveFields = Set.of();
+    /** UNSAFE, NOT PCI DSS COMPLIANT: see {@link #setUnsafeNonPciDssCompliantRawMessageLoggingEnabled(boolean)}. */
+    private boolean unsafeNonPciDssCompliantRawMessageLoggingEnabled;
 
     /**
      * Is force string encoding boolean.
@@ -223,6 +230,60 @@ public class MessageFactory<T extends IsoMessage> {
                 }
             }
         }
+    }
+
+    /**
+     * Returns the field numbers propagated to every message this factory creates or
+     * parses, to be masked by their no-arg {@link IsoMessage#debugString()}. Default is
+     * an empty set.
+     *
+     * @return the sensitive fields
+     */
+    public Set<Integer> getSensitiveFields() {
+        return sensitiveFields;
+    }
+
+    /**
+     * Sets the field numbers to be propagated to every message this factory creates or
+     * parses (via {@link IsoMessage#setSensitiveFields(Set)}), so their no-arg
+     * {@link IsoMessage#debugString()} masks them without callers having to remember
+     * to pass them in on every call. {@link IsoMessage#COMMONLY_SENSITIVE_FIELDS} is a
+     * reasonable starting point.
+     *
+     * @param value the field numbers to mask
+     */
+    public void setSensitiveFields(Set<Integer> value) {
+        if (value == null) {
+            throw new IllegalArgumentException("Cannot set null sensitiveFields.");
+        }
+        sensitiveFields = Set.copyOf(value);
+    }
+
+    /**
+     * Returns true if, on a parse error caused by a message type with no parsing guide,
+     * the raw message buffer is hex-encoded and included in the log line. See
+     * {@link #setUnsafeNonPciDssCompliantRawMessageLoggingEnabled(boolean)}. Default is false.
+     *
+     * @return the boolean
+     */
+    public boolean isUnsafeNonPciDssCompliantRawMessageLoggingEnabled() {
+        return unsafeNonPciDssCompliantRawMessageLoggingEnabled;
+    }
+
+    /**
+     * UNSAFE, NOT PCI DSS COMPLIANT. When enabled, if a message cannot be parsed because
+     * its type has no parsing guide, the full raw message buffer is hex-encoded and
+     * written to the log at ERROR level. ISO8583 messages commonly carry cardholder data
+     * (PANs, track data, PIN blocks), so enabling this will write that data to your logs.
+     * <p>
+     * This is intended only for temporary use while developing or debugging a new
+     * parsing guide, never in production, and never against real cardholder data. Default
+     * is false.
+     *
+     * @param flag the flag
+     */
+    public void setUnsafeNonPciDssCompliantRawMessageLoggingEnabled(boolean flag) {
+        unsafeNonPciDssCompliantRawMessageLoggingEnabled = flag;
     }
 
     /**
@@ -449,6 +510,7 @@ public class MessageFactory<T extends IsoMessage> {
         m.setCharacterEncoding(encoding);
         m.setForceStringEncoding(forceStringEncoding);
         m.setEncodeVariableLengthFieldsInHex(variableLengthFieldsInHex);
+        m.setSensitiveFields(sensitiveFields);
 
         //Copy the values from the template
         IsoMessage templ = typeTemplates.get(type);
@@ -510,6 +572,7 @@ public class MessageFactory<T extends IsoMessage> {
         resp.setEtx(etx);
         resp.setForceSecondaryBitmap(forceb2);
         resp.setEncodeVariableLengthFieldsInHex(request.isEncodeVariableLengthFieldsInHex());
+        resp.setSensitiveFields(request.getSensitiveFields());
         //Copy the values from the template or the request (request has preference)
         IsoMessage templ = typeTemplates.get(resp.getType());
         if (templ == null) {
@@ -674,11 +737,18 @@ public class MessageFactory<T extends IsoMessage> {
         Map<Integer, FieldParseInfo> parseGuide = parseMap.get(type);
         List<Integer> index = parseOrder.get(type);
         if (index == null) {
-            // Do not log or embed the raw message buffer here: it may contain sensitive
-            // cardholder data (PAN, track data, PIN blocks) and this is an error path that
-            // is more likely than most to end up in aggregated/centralized logs.
-            log.error("ISO8583 MessageFactory has no parsing guide for message type {} (buffer length {})",
-                    String.format("%04x", type), buf.length);
+            // Do not log or embed the raw message buffer here by default: it may contain
+            // sensitive cardholder data (PAN, track data, PIN blocks) and this is an error
+            // path that is more likely than most to end up in aggregated/centralized logs.
+            // See setUnsafeNonPciDssCompliantRawMessageLoggingEnabled(boolean) for an opt-in,
+            // hex-encoded exception for development/debugging purposes only.
+            if (unsafeNonPciDssCompliantRawMessageLoggingEnabled) {
+                log.error("ISO8583 MessageFactory has no parsing guide for message type {} (buffer length {}), raw message (hex): {}",
+                        String.format("%04x", type), buf.length, HexCodec.hexEncode(buf, 0, buf.length));
+            } else {
+                log.error("ISO8583 MessageFactory has no parsing guide for message type {} (buffer length {})",
+                        String.format("%04x", type), buf.length);
+            }
             throw new ParseException(String.format(
                     "ISO8583 MessageFactory has no parsing guide for message type %04x", type), 0);
         }
@@ -787,6 +857,7 @@ public class MessageFactory<T extends IsoMessage> {
         m.setBinaryFields(binaryFields);
         m.setBinaryBitmap(binBitmap);
         m.setForceStringEncoding(forceStringEncoding);
+        m.setSensitiveFields(sensitiveFields);
         return m;
     }
 

--- a/src/test/java/com/solab/iso8583/TestIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/TestIsoMessage.java
@@ -198,6 +198,36 @@ class TestIsoMessage {
                 "field 35 is in the default sensitive field set and must be masked");
     }
 
+    @Test
+    void testFactorySensitiveFieldsPropagation() throws IOException, ParseException {
+        Assertions.assertEquals(java.util.Set.of(), mf.getSensitiveFields(), "default must be empty");
+        mf.setSensitiveFields(java.util.Set.of(35));
+
+        //Propagated to newly created messages
+        final IsoMessage created = mf.newMessage(0x200);
+        Assertions.assertEquals(java.util.Set.of(35), created.getSensitiveFields());
+        Assertions.assertFalse(created.debugString().contains("4591700012340000="),
+                "no-arg debugString() must mask field 35 once configured on the factory");
+
+        //Propagated to parsed messages
+        final byte[] buf = created.writeData();
+        final IsoMessage parsed = mf.parseMessage(buf, mf.getIsoHeader(0x200).length());
+        Assertions.assertEquals(java.util.Set.of(35), parsed.getSensitiveFields());
+
+        //Propagated to response messages
+        final IsoMessage response = mf.createResponse(created);
+        Assertions.assertEquals(java.util.Set.of(35), response.getSensitiveFields());
+
+        Assertions.assertThrows(IllegalArgumentException.class, () -> mf.setSensitiveFields(null));
+    }
+
+    @Test
+    void testUnsafeRawMessageLoggingFlagDefaultsToFalse() {
+        Assertions.assertFalse(mf.isUnsafeNonPciDssCompliantRawMessageLoggingEnabled());
+        mf.setUnsafeNonPciDssCompliantRawMessageLoggingEnabled(true);
+        Assertions.assertTrue(mf.isUnsafeNonPciDssCompliantRawMessageLoggingEnabled());
+    }
+
     private static String formatWithSpace(final String toFormat) {
         return toFormat.replaceAll("..", "$0 ");
     }

--- a/src/test/java/com/solab/iso8583/TestIsoMessage.java
+++ b/src/test/java/com/solab/iso8583/TestIsoMessage.java
@@ -177,6 +177,27 @@ class TestIsoMessage {
         Assertions.assertEquals(formatWithSpace(expected), formatWithSpace(hexParseBinary));
     }
 
+    @Test
+    void testMaskedDebugString() {
+        final IsoMessage iso = mf.newMessage(0x200);
+        final String plain = iso.debugString();
+        Assertions.assertEquals(plain, iso.debugString(java.util.Set.of()),
+                "debugString() must be equivalent to masking no fields");
+        Assertions.assertTrue(plain.contains("4591700012340000="), "field 35 should be in clear text");
+
+        final String masked = iso.debugString(java.util.Set.of(35));
+        Assertions.assertEquals(plain.length(), masked.length(),
+                "masking must not change the overall length of the debug string");
+        Assertions.assertFalse(masked.contains("4591700012340000="), "field 35 value must be masked");
+        Assertions.assertTrue(masked.contains("*".repeat("4591700012340000=".length())),
+                "field 35 must be replaced by mask characters of the same length");
+        Assertions.assertTrue(masked.contains("456"), "field 32 must remain in clear text");
+
+        final String maskedCommon = iso.debugString(IsoMessage.COMMONLY_SENSITIVE_FIELDS);
+        Assertions.assertFalse(maskedCommon.contains("4591700012340000="),
+                "field 35 is in the default sensitive field set and must be masked");
+    }
+
     private static String formatWithSpace(final String toFormat) {
         return toFormat.replaceAll("..", "$0 ");
     }

--- a/src/test/java/com/solab/iso8583/TestParsing.java
+++ b/src/test/java/com/solab/iso8583/TestParsing.java
@@ -56,6 +56,26 @@ class TestParsing {
 		Assertions.assertThrows(ParseException.class, () -> mf.parseMessage(new byte[]{ 2, 0, (byte)128, 0, 0, 0, 0, 0, 0, 0 }, 0));
 	}
 
+	/** When the message type has no parsing guide, the error must not leak the raw
+	 * message content (which may contain cardholder data) into the log or the
+	 * exception message. */
+	@Test
+	void testUnknownMessageTypeDoesNotLeakBufferContents() {
+		final IsoMessage m = mf.newMessage(0x200);
+		final byte[] data = m.writeData();
+		final int headerLength = mf.getIsoHeader(0x200).length();
+		//Corrupt the message type to one with no parsing guide configured, keep the rest intact
+		data[headerLength] = '9';
+		data[headerLength + 1] = '9';
+		data[headerLength + 2] = '9';
+		data[headerLength + 3] = '9';
+		final ParseException ex = Assertions.assertThrows(ParseException.class,
+				() -> mf.parseMessage(data, headerLength));
+		Assertions.assertTrue(ex.getMessage().contains("9999"), "Exception should mention the message type");
+		Assertions.assertFalse(ex.getMessage().contains("4591700012340000="),
+				"Exception message must not contain field content from the buffer");
+	}
+
 	@Test
 	void testNoFields() {
 		Assertions.assertThrows(ParseException.class, () -> mf.parseMessage("0210B23A80012EA080180000000014000004".getBytes(), 0));

--- a/src/test/java/com/solab/iso8583/TestParsing.java
+++ b/src/test/java/com/solab/iso8583/TestParsing.java
@@ -76,6 +76,25 @@ class TestParsing {
 				"Exception message must not contain field content from the buffer");
 	}
 
+	/** Enabling the unsafe/non-PCI-DSS-compliant raw logging flag must not change the
+	 * thrown exception (only the opt-in log line gains the hex-encoded buffer). */
+	@Test
+	void testUnknownMessageTypeStillThrowsWithUnsafeLoggingEnabled() {
+		mf.setUnsafeNonPciDssCompliantRawMessageLoggingEnabled(true);
+		final IsoMessage m = mf.newMessage(0x200);
+		final byte[] data = m.writeData();
+		final int headerLength = mf.getIsoHeader(0x200).length();
+		data[headerLength] = '9';
+		data[headerLength + 1] = '9';
+		data[headerLength + 2] = '9';
+		data[headerLength + 3] = '9';
+		final ParseException ex = Assertions.assertThrows(ParseException.class,
+				() -> mf.parseMessage(data, headerLength));
+		Assertions.assertTrue(ex.getMessage().contains("9999"));
+		Assertions.assertFalse(ex.getMessage().contains("4591700012340000="),
+				"Exception message itself must still never contain field content, regardless of the flag");
+	}
+
 	@Test
 	void testNoFields() {
 		Assertions.assertThrows(ParseException.class, () -> mf.parseMessage("0210B23A80012EA080180000000014000004".getBytes(), 0));


### PR DESCRIPTION
MessageFactory.parseMessage() used to embed the entire raw message buffer
in both the log line and the ParseException message when a message type
had no parsing guide. ISO8583 traffic routinely carries PANs, track data
and PIN blocks, so dumping the raw buffer on this error path is a
cardholder-data exposure risk in centralized/aggregated logs.

IsoMessage.debugString() also had no way to avoid printing every field's
clear-text value. Added an overload, debugString(Set<Integer>), that
replaces the specified field numbers' content with mask characters while
preserving the real length header, plus a COMMONLY_SENSITIVE_FIELDS
constant (PAN, track 1/2/3, PIN block, ICC data) as a starting point.
debugString() keeps its previous behavior via debugString(Set.of()).