### PR TITLE
Generate a CycloneDX SBOM and publish it alongside the jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -144,6 +144,33 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.cyclonedx</groupId>
+                <artifactId>cyclonedx-maven-plugin</artifactId>
+                <version>2.9.2</version>
+                <configuration>
+                    <outputFormat>json</outputFormat>
+                    <outputName>bom</outputName>
+                    <!-- Default (true) infers from the current invocation whether a deploy
+                         is coming and skips otherwise; that would mean no SBOM is produced
+                         during a plain "mvn verify"/"package" (e.g. in PR builds), only
+                         during an actual release. Generate it on every build instead. -->
+                    <skipNotDeployed>false</skipNotDeployed>
+                </configuration>
+                <executions>
+                    <execution>
+                        <!-- Generates target/bom.json and attaches it as an additional
+                             deployable artifact (classifier "cyclonedx", type "json"), so
+                             it's published to Maven Central alongside the jar/sources/javadoc
+                             (and signed by the gpg plugin below, like those other artifacts). -->
+                        <id>build-sbom</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>makeBom</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-gpg-plugin</artifactId>
                 <version>3.2.8</version>


### PR DESCRIPTION
## Summary
- Adds `cyclonedx-maven-plugin` (2.9.2), bound to the `package` phase, generating `target/bom.json` (CycloneDX 1.6, JSON format).
- The plugin auto-attaches the SBOM as an additional artifact (classifier `cyclonedx`, type `json`), which gets signed by the existing `maven-gpg-plugin` step and published to Maven Central alongside the jar/sources/javadoc on release, the same way those already are — no extra plugin needed to attach it.
- Explicitly sets `skipNotDeployed` to `false`: the plugin's default (`true`) infers from the current Maven invocation whether a deploy is coming and silently skips SBOM generation otherwise, which would mean a plain `mvn verify`/`package` (e.g. in PR builds / this repo's `build.yml`) never produces or exercises this step — only an actual release would. Disabling that heuristic means the SBOM is generated and checkable on every build.

An SBOM doesn't add much information here today (the project has a single compile-scope dependency, `slf4j-api`), but it publishes that in a standard, machine-readable format (CycloneDX) that vulnerability-management tooling (Dependency-Track, Grype, Trivy, etc.) can ingest automatically, which is increasingly expected/required for dependencies used in payment-processing systems.

## Test plan
- [x] `mvn package` produces `target/bom.json` (CycloneDX 1.6) and attaches it as `j8583-<version>-cyclonedx.json`
- [x] `mvn verify` (matches `build.yml`'s build command) also produces and attaches it correctly
- [x] SBOM content verified: lists only the single compile-scope dependency (`org.slf4j:slf4j-api:2.0.18`), correctly excluding test-scope dependencies
- [x] Full test suite (154 tests) passes unaffected


---
_Generated by [Claude Code](https://claude.ai/code/session_01QpoJzBnhCAJ6vBi4gQDAHG)_