### PR TITLE
Docs modernization Phase 1: fix outdated content in Maven site APT pages

### DIFF
--- a/src/site/apt/encoders.apt
+++ b/src/site/apt/encoders.apt
@@ -42,13 +42,18 @@ public class ListEncoder implements CustomField<List<String>> {
 
 +-----
   messageFactory.setCustomField(62, new ListEncoder());
-  IsoMessage parsed = messageFactory.parse(someBytes, 0);
+  IsoMessage parsed = messageFactory.parseMessage(someBytes, 0);
   assert parsed.getObjectValue(62) instanceof List
   IsoMessage nm = messageFactory.newMessage(0x200);
   //you need to pass the CustomField
-  nm.setValue(62, Arrays.asList("a", "b", "c", "d", "e"), messageFactory.getCustomField(126), IsoType.LLLVAR, 0);
+  nm.setValue(62, Arrays.asList("a", "b", "c", "d", "e"), messageFactory.getCustomField(62), IsoType.LLLVAR, 0);
   //when nm gets written, field 62 will be "009a,b,c,d,e"
 +-----
+
+  <<Note:>> If your custom field only needs to handle binary messages, you can implement
+  <<<CustomBinaryField>>> instead of <<<CustomField>>>. It adds <<<decodeBinaryField()>>> and
+  <<<encodeBinaryField()>>> methods for working directly with byte arrays, and the String-based
+  methods inherited from <<<CustomField>>> may simply return <<<null>>> in that case.
 
   If you setup CustomField encoders in a MessageFactory and then you configure it using the XML configuration file,
   the values for fields that have CustomField encoders defined will be decoded with them. In this example, if you

--- a/src/site/apt/iso8583.apt
+++ b/src/site/apt/iso8583.apt
@@ -23,9 +23,15 @@ Introduction to ISO8583
 | Fixed-length |                |
 | Alphanumeric | ALPHA          | Fixed-width alphanumeric values, padded with spaces to the right.|
 *--------------*----------------*-----------------+
+| Date         | DATE4          | Date in format mmdd, fixed width of 4. |
+*--------------*----------------*-----------------+
+| Date         | DATE6          | Date in format yyMMdd, fixed width of 6. |
+*--------------*----------------*-----------------+
 | Date         | DATE10         | Date in format mmddHHMMSS, fixed width of 10. |
 *--------------*----------------*-----------------+
-| Date         | DATE4          | Date in format mmdd, fixed width of 4. |
+| Date         | DATE12         | Date in format yyMMddHHMMSS, fixed width of 12. |
+*--------------*----------------*-----------------+
+| Date         | DATE14         | Date in format yyyyMMddHHMMSS, fixed width of 14. |
 *--------------*----------------*-----------------+
 | Expiration Date | DATE_EXP     | Date in format yymm, fixed width of 4. Used for credit card expiration dates. |
 *--------------*----------------*-----------------+
@@ -37,8 +43,13 @@ Introduction to ISO8583
 *--------------*----------------*-----------------+
 | LLLVAR       | LLLVAR         | Variable-width alphanumeric value, up to 999 characters long. The length of the value is encoded in the first 3 characters of the value, for example "HEY" is encoded as 003HEY |
 *--------------*----------------*-----------------+
+| LLLLVAR      | LLLLVAR        | Variable-width alphanumeric value, up to 9999 characters long. The length of the value is encoded in the first 4 characters of the value, for example "HEY" is encoded as 0003HEY |
+*--------------*----------------*-----------------+
 | Fixed-length |                | Similar to ALPHA, but stores byte arrays directly instead of text.
 | binary       | BINARY         |
+*--------------*----------------*-----------------+
+| Fixed-length |                | Same as BINARY, but always treated as a binary field even when the rest
+| binary       | RAW_BINARY     | of the message is encoded as text.
 *--------------*----------------*-----------------+
 | Binary       | LLBIN          | Similar to LLVAR, but stores byte arrays directly instead of text.
 | LLVAR        |                |
@@ -46,7 +57,18 @@ Introduction to ISO8583
 | Binary       | LLLBIN         | Similar to LLLVAR, but stores byte arrays directly instead of text.
 | LLLVAR       |                |
 *--------------*----------------*-----------------+
+| Binary       | LLLLBIN        | Similar to LLLLVAR, but stores byte arrays directly instead of text.
+| LLLLVAR      |                |
+*--------------*----------------*-----------------+
 ISO 8583 types and their corresponding j8583 types
+
+  <<Note:>> this table lists the most commonly used types. j8583 also supports several
+  variants used by specific providers, such as BCD-encoded lengths (<<<LLBCDBIN>>>,
+  <<<LLLBCDBIN>>>, <<<LLLLBCDBIN>>>) and fields whose length is a single literal byte
+  (<<<LLBINLENGTHNUM>>>, <<<LLBINLENGTHALPHANUM>>>, <<<LLBINLENGTHBIN>>>, and their
+  4-byte-length counterparts). See the <<<IsoType>>> enum in the
+  {{{https://javadoc.io/doc/io.github.thibaudledent.j8583/j8583}Javadoc}} for the complete,
+  up-to-date list.
 
 * Common scenarios
 
@@ -127,8 +149,11 @@ ISO 8583 types and their corresponding j8583 types
   In these cases, the sender first encodes the whole message, measures it, and sends the length as a 2- or 4-byte
   unsigned integer (most significant bit first). This way the receiver knows to read 2 or 4 bytes, interpret them
   as an unsigned integer, and read those many bytes to get an ISO message. Using 2 bytes allows for messages of up
-  to 65535 bytes, and 4 bytes allows for 2.14 billion bytes long, which is a bit of overkill, given that a message
-  can be as long as 127290 bytes, if it's encoded in ASCII and has 127 LLLVAR fields each with 999 characters.
+  to 65535 bytes, and 4 bytes allows for over 4 billion bytes long. A message encoded in ASCII with 127 LLLVAR
+  fields each holding 999 characters can already be around 127290 bytes long, which is over the 2-byte limit; and
+  j8583 also supports LLLLVAR/LLLLBIN fields (up to 9999 characters each), so providers that use those can produce
+  messages well over a million bytes. Because of this, a 2-byte length header is only safe if you know your
+  provider's messages will stay under 65535 bytes; otherwise a 4-byte length header is the safer choice.
 
 *** Message terminator
 

--- a/src/site/apt/simpleparser.apt
+++ b/src/site/apt/simpleparser.apt
@@ -8,12 +8,15 @@ Simple ISO8583 message parser
   a config file specified in the command line.
 
   To use this program, set up your classpath to include SLF4J and j8583, invoke
-  the <<com.solab.iso8583.util.SimpleParser>> and pass it the full path to your
-  j8583 configuration file. For example:
+  the <<com.solab.iso8583.util.SimpleParser>> class and pass it the full path (or URL) to
+  your j8583 configuration file. For example:
 
 +-----
-java -cp lib/slf4j-api-1.7.7.jar:lib/slf4j-simple-1.7.7.jar:lib/j8583-1.10.2.jar com.solab.iso8583.util.SimpleParser /tmp/j8583-config.xml
+java -cp lib/slf4j-api-2.0.18.jar:lib/slf4j-simple-2.0.18.jar:lib/j8583-1.26.2.jar com.solab.iso8583.util.SimpleParser /tmp/j8583-config.xml
 +-----
+
+  If you don't pass any argument, the program will try to configure the MessageFactory from a
+  default configuration file found on the classpath (see <<<ConfigParser.configureFromDefault()>>>).
 
   You can paste an ISO8583 message encoded as text and the program will parse it, showing
   the message type, bitmap and the value of each field.

--- a/src/site/apt/spring.apt
+++ b/src/site/apt/spring.apt
@@ -32,7 +32,15 @@ Configuration via Spring
 *------------------------+---------------------------------+
 | useBinaryBitmap        | Set this flag to make newly created messages encode their bitmap in binary format, even if the rest of the message is encoded in text. This only works for text messages and has no effect on binary messages.
 *------------------------+---------------------------------+
-| useBinaryMessages      | Can be true or false (default false). The factory passes this value to new messages so that they're encoded in binary or ASCII.
+| useTertiaryBitmap      | If true, field 65 is interpreted as a tertiary bitmap, allowing messages to use fields 129-192.
+*------------------------+---------------------------------+
+| variableLengthFieldsInHex | If true, the length header of variable-length fields (LLVAR, LLLVAR, etc.) is encoded/decoded in hexadecimal instead of decimal.
+*------------------------+---------------------------------+
+| binaryHeader           | Can be true or false (default false). If true, the message header portion is written/parsed as binary.
+*------------------------+---------------------------------+
+| binaryFields           | Can be true or false (default false). If true, the message fields portion is written/parsed as binary.
+*------------------------+---------------------------------+
+| useBinaryMessages      | <<Deprecated>>, use <<<binaryHeader>>> and <<<binaryFields>>> instead. Can be true or false (default false); setting it sets both <<<binaryHeader>>> and <<<binaryFields>>> to the same value.
 *------------------------+---------------------------------+
 
   Example:

--- a/src/site/apt/xmlconf.apt
+++ b/src/site/apt/xmlconf.apt
@@ -69,7 +69,8 @@ XML Configuration
   Each <<<parse>>> element defines a parsing template for a message type. It must include all the fields that
   an incoming message can contain, each field with its type and length (if needed). Only ALPHA and NUMERIC
   types need to have a length specified. The other types either have a fixed length, or have their length
-  specified as part of the field (LLVAR and LLLVAR).
+  specified as part of the field (LLVAR, LLLVAR, LLLLVAR and their binary/BCD variants). See the
+  {{{iso8583.html}ISO8583 guide}} for the complete list of supported types.
 
 +-----
 <parse type="0210">


### PR DESCRIPTION
## Summary

First phase of the documentation modernization effort. This PR keeps the existing Maven Site format (APT files under `src/site/apt`) but verifies each page against the current codebase and fixes outdated or incorrect content. No structural changes yet — those come in Phase 2.

- **iso8583.apt**: added the `IsoType` values that were missing from the type table (`DATE6`, `DATE12`, `DATE14`, `LLLLVAR`, `RAW_BINARY`, `LLLLBIN`), added a note pointing to the BCD-length and single-byte-length variants (`LLBCDBIN`, `LLBINLENGTHNUM`, etc.), and corrected the message-length example in the "Asynchronous transmission" section, which assumed `LLLVAR` (999 chars) was the largest variable-length type — `LLLLVAR`/`LLLLBIN` (9999 chars) exist now, so the old "4-byte header is overkill" claim no longer holds in all cases.
- **spring.apt**: documented `binaryHeader`/`binaryFields` (which superseded the now-deprecated `useBinaryMessages`), plus `useTertiaryBitmap` and `variableLengthFieldsInHex`, none of which were in the properties table.
- **encoders.apt**: fixed a copy-paste bug in the example (`messageFactory.getCustomField(126)` instead of `getCustomField(62)`), corrected `parse()` to the actual method name `parseMessage()`, and added a note about `CustomBinaryField` for binary-only custom fields.
- **simpleparser.apt**: updated the example command's jar/SLF4J version numbers (were pinned to `j8583-1.10.2`/`slf4j-1.7.7`) and documented the zero-argument default-config behavior (`ConfigParser.configureFromDefault()`).
- **xmlconf.apt**: pointed to the full list of supported field types instead of only mentioning `LLVAR`/`LLLVAR`.

Every change above was verified directly against the current source (`IsoType`, `MessageFactory`, `IsoMessage`, `ConfigParser`, `SimpleParser`, etc.) rather than guessed. `guide.apt`, `index.apt`, and `polyglot.apt` were checked as well and found accurate, so they're unchanged. The Spanish translations under `src/site/es/apt` were left as-is since the plan for Phase 2 is to consolidate everything into a single English Markdown doc tree under `docs/`.

## Next steps (Phase 2, separate PR after this one is merged)

- Convert these APT pages into clean Markdown under a new `docs/` directory.
- Remove `src/site` entirely (both `en` and `es`, plus `site.xml`/`site_es.xml`) once the Maven Site is no longer needed.
- Update `README.md` to link to the new `docs/` and to the published Javadoc.

## Test plan

- [x] Read the current source for every class/behavior referenced in the changed docs to confirm accuracy.
- [x] Visual/structural check of the APT table syntax (column counts match existing tables).
- Documentation-only change; no code/tests affected.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QFSn5Kft2gaBbRjMW6VGbN)_