### PR TITLE
Documentation review: fix inaccuracies, document sensitive-field masking

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,8 +13,8 @@ For the full API reference, see the [Javadoc on javadoc.io](https://javadoc.io/d
   structure, data types, common fields and message types, and the differences between ASCII and
   binary encoding.
 - [Usage guide](usage-guide.md) — the `MessageFactory` and `IsoMessage` classes, and how to
-  configure headers, templates, parsing templates, trace number generation and custom field
-  encoders.
+  configure headers, templates, parsing templates, trace number generation, custom field
+  encoders, and masking sensitive fields when logging.
 - [XML configuration](xml-configuration.md) — configuring a `MessageFactory` from an XML file
   instead of programmatically: headers, templates, parsing guides, template inheritance, and
   composite fields.

--- a/docs/iso8583-protocol.md
+++ b/docs/iso8583-protocol.md
@@ -55,9 +55,10 @@ counterpart:
 | Variable-length binary | `LLLLBIN` | Similar to `LLLLVAR`, but stores byte arrays directly instead of text. |
 
 This table lists the most commonly used types. j8583 also supports several variants used by
-specific providers, such as BCD-encoded lengths (`LLBCDBIN`, `LLLBCDBIN`, `LLLLBCDBIN`) and fields
-whose length is a single literal byte (`LLBINLENGTHNUM`, `LLBINLENGTHALPHANUM`,
-`LLBINLENGTHBIN`, and their 4-byte-length counterparts). See the `IsoType` enum in the
+specific providers, such as BCD-encoded lengths (`LLBCDBIN`, `LLLBCDBIN`, `LLLLBCDBIN`,
+`LLBCDLENGTHALPHANUM`) and fields whose length is a single literal byte (`LLBINLENGTHNUM`,
+`LLBINLENGTHALPHANUM`, `LLBINLENGTHBIN`, and their 2-byte-length counterparts, `LLLLBINLENGTHNUM`,
+`LLLLBINLENGTHALPHANUM` and `LLLLBINLENGTHBIN`). See the `IsoType` enum in the
 [Javadoc](https://javadoc.io/doc/io.github.thibaudledent.j8583/j8583) for the complete,
 up-to-date list.
 

--- a/docs/simple-parser.md
+++ b/docs/simple-parser.md
@@ -15,5 +15,6 @@ java -cp lib/slf4j-api-2.0.18.jar:lib/slf4j-simple-2.0.18.jar:lib/j8583-1.26.2.j
 If you don't pass any argument, the program tries to configure the `MessageFactory` from a
 default configuration file found on the classpath (see `ConfigParser.configureFromDefault()`).
 
-You can then paste an ISO 8583 message encoded as text, and the program will parse it, showing
-the message type, bitmap and the value of each field.
+You can then paste an ISO 8583 message encoded as text, without any ISO header, and the program
+will parse it, showing the message type and, for each field present in the message, its number,
+type, length and value.

--- a/docs/spring-integration.md
+++ b/docs/spring-integration.md
@@ -26,6 +26,8 @@ The properties you'll typically want to set up in the Spring config are:
 | `binaryHeader` | If `true`, the message header portion is written/parsed as binary. Default `false`. |
 | `binaryFields` | If `true`, the message fields portion is written/parsed as binary. Default `false`. |
 | `useBinaryMessages` | **Deprecated**, use `binaryHeader` and `binaryFields` instead. Setting it sets both `binaryHeader` and `binaryFields` to the same value. |
+| `sensitiveFields` | A set of field numbers to mask with `*` when calling `debugString()` on messages this factory creates or parses. See [Masking sensitive fields when logging](usage-guide.md#masking-sensitive-fields-when-logging). |
+| `unsafeNonPciDssCompliantRawMessageLoggingEnabled` | **Unsafe, not PCI DSS compliant.** If `true`, logs the raw, hex-encoded message buffer at `ERROR` level when a message can't be parsed because its type has no parsing guide. Default `false`; only meant for temporary use while developing or debugging. |
 
 Example:
 

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -16,10 +16,47 @@ However, it can be cumbersome to programmatically create `IsoMessage`s all the t
 `MessageFactory` is a big aid in creating `IsoMessage`s with predefined values; it can also set
 the date and the trace number on each new message.
 
+## A quick example
+
+Before going through each configuration option in detail, here's a minimal example that ties the
+concepts above together: a `MessageFactory` with a message template and a parsing template, used
+to create a message and parse it back.
+
+```java
+MessageFactory<IsoMessage> mf = new MessageFactory<>();
+
+// A template: values shared by every 0200 message the factory creates
+IsoMessage template = new IsoMessage();
+template.setType(0x200);
+template.setValue(3, 0, IsoType.NUMERIC, 6);
+mf.addMessageTemplate(template);
+
+// A parsing template: tells the factory how to read an incoming 0200 message
+Map<Integer, FieldParseInfo> parseGuide = new HashMap<>();
+parseGuide.put(3, FieldParseInfo.getInstance(IsoType.NUMERIC, 6, mf.getCharacterEncoding()));
+parseGuide.put(41, FieldParseInfo.getInstance(IsoType.ALPHA, 8, mf.getCharacterEncoding()));
+mf.setParseMap(0x200, parseGuide);
+
+IsoMessage message = mf.newMessage(0x200);
+message.setValue(41, "TERM0001", IsoType.ALPHA, 8);
+byte[] data = message.writeData();
+
+IsoMessage parsed = mf.parseMessage(data, 0);
+// parsed now has field 3 ("000000", copied from the template) and field 41 ("TERM0001")
+```
+
+`IsoMessage` can also write itself directly to an `OutputStream` (with `write()`) or to a
+`ByteBuffer` (with `writeToBuffer()`); both can prepend a length header, useful when framing
+messages sent over a socket — see [message terminator](iso8583-protocol.md#message-terminator) for
+more on that. Setting up templates and parsing guides by hand like this works, but for anything
+beyond a handful of fields it's usually easier to use an [XML configuration
+file](xml-configuration.md) instead, as described below.
+
 ## Configuring the MessageFactory
 
-There are five main things you can configure in a `MessageFactory`: ISO headers, message
-templates, parsing templates, a `TraceNumberGenerator`, and custom field encoders.
+There are six main things you can configure in a `MessageFactory`: ISO headers, message
+templates, parsing templates, a `TraceNumberGenerator`, custom field encoders, and which fields to
+mask when logging messages.
 
 ### ISO headers
 
@@ -78,6 +115,35 @@ pass the `MessageFactory` a `CustomField` for every field where you want to stor
 so that parsed messages will return the objects decoded by the `CustomField`s instead of just
 strings; and when you set a value in an `IsoMessage`, you can specify the `CustomField` to be used
 to encode the value as a `String`. See [Custom field encoders](custom-field-encoders.md) for more.
+
+### Masking sensitive fields when logging
+
+`IsoMessage` has a `debugString()` method that returns a text representation of the message,
+useful for logging, without needing to encode it first. By default it shows every field in clear
+text, which is a problem for real ISO 8583 traffic: fields like the PAN, track data or PIN block
+are cardholder data that shouldn't end up in application logs.
+
+Tell the `MessageFactory` which fields to mask, and every message it creates or parses will pick
+up the setting automatically:
+
+```java
+messageFactory.setSensitiveFields(IsoMessage.COMMONLY_SENSITIVE_FIELDS);
+IsoMessage m = messageFactory.parseMessage(someBytes, 0);
+log.debug(m.debugString());
+```
+
+`IsoMessage.COMMONLY_SENSITIVE_FIELDS` (fields 2, 34, 35, 36, 45, 52 and 55) is a reasonable
+starting point, but you should review it against the fields your own provider actually uses for
+cardholder data. Masking replaces a field's value with `*` characters of the same length; the
+length header of variable-length fields still shows the real length. You can also skip the
+factory-wide setting and call `debugString(Set<Integer>)` directly on a message with an explicit
+set of fields to mask.
+
+`MessageFactory` also has an `unsafeNonPciDssCompliantRawMessageLoggingEnabled` flag (disabled by
+default) that logs the raw, hex-encoded message buffer at `ERROR` level when a message can't be
+parsed because its type has no parsing guide. As the name says, this is unsafe and not PCI DSS
+compliant — only enable it temporarily while developing or debugging a new parsing guide, never in
+production or against real cardholder data.
 
 ## XML configuration
 


### PR DESCRIPTION
## Summary

A focused review of the `docs/` guides and README against the current codebase, fixing a couple of inaccuracies and filling two gaps: a missing quick-start example and an undocumented security-relevant feature.

- **`iso8583-protocol.md`**: the note about `IsoType` variants whose length is a single literal byte claimed the 4-letter-prefixed counterparts (`LLLLBINLENGTHNUM`, etc.) use a 4-byte length. Checked the parser code (`BinLengthLlllNumParseInfo` and friends) — it's actually 2 bytes. Fixed the wording and named the types explicitly. Also added `LLBCDLENGTHALPHANUM`, a BCD-length variant that exists in `IsoType` but wasn't mentioned in the docs at all.
- **`simple-parser.md`**: said the bundled CLI tool prints "the message type, bitmap and value of each field" — `SimpleParser.java` doesn't print the bitmap; it prints the message type and, per field, its number/type/length/value. Also noted the "paste without an ISO header" requirement, which is in the tool's own prompt but missing from the doc.
- **`usage-guide.md`**:
  - Added a short "A quick example" section with a runnable code sample that builds a `MessageFactory` with a message template and a parsing template, creates a message, and parses it back. Previously the guide explained these concepts entirely in prose with no code at all, unlike every other guide in `docs/`.
  - Added a "Masking sensitive fields when logging" section documenting `IsoMessage#debugString()`/`debugString(Set)`, `MessageFactory#setSensitiveFields`/`IsoMessage#setSensitiveFields`, `COMMONLY_SENSITIVE_FIELDS`, and the `unsafeNonPciDssCompliantRawMessageLoggingEnabled` flag — a shipped, PCI-DSS-oriented log-masking feature that had no mention anywhere in the docs.
- **`spring-integration.md`**: added `sensitiveFields` and `unsafeNonPciDssCompliantRawMessageLoggingEnabled` to the bean properties table, matching the new usage-guide section.
- **`README.md`** (docs index): updated the usage-guide summary line and the "six things you can configure" intro sentence so the new masking topic is discoverable from the index.

Everything else (the `IsoType` table, XML configuration examples, `CompositeField` encode/decode example, custom field encoder guide, Groovy/Scala shorthand, existing Spring properties, trace generator behavior, internal doc links/anchors) was checked against the source and found accurate — left untouched per the incremental-changes approach.

## Test plan

- [x] Verified every code claim (type names, byte lengths, method signatures, property names/defaults) against the current `src/main/java` source.
- [x] Hand-traced the new quick-example code path (`FieldParseInfo.getInstance`, `MessageFactory#newMessage`/`setParseMap`/`parseMessage`, `IsoMessage#setValue`) against the actual implementations to confirm it's correct Java.
- [x] Checked all internal markdown links/anchors (including the new `usage-guide.md#masking-sensitive-fields-when-logging` link from `spring-integration.md`) resolve correctly.
- Docs-only change; no build/test run required.


---
_Generated by [Claude Code](https://claude.ai/code/session_01LgWG3NijJvJ8neZGE1cZDs)_