### PR TITLE
Add consistent home/prev/next navigation to docs guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,7 @@
 # j8583 documentation
 
+[← Back to main README](../README.md)
+
 j8583 is a Java library to generate and read ISO 8583 messages. It does not handle sending or
 receiving them over a network connection — that part is up to you — but it parses the data you
 have read and generates the data you need to write, either as a byte array, a `ByteBuffer`, or

--- a/docs/custom-field-encoders.md
+++ b/docs/custom-field-encoders.md
@@ -1,5 +1,7 @@
 # Custom field encoders
 
+[🏠 Documentation home](README.md)
+
 Sometimes a field contains several sub-fields or separate pieces of data. j8583 will only parse
 the field itself for you — you still have to parse those pieces of data yourself when reading a
 message, and encode several pieces of data into a field yourself when creating one.
@@ -79,3 +81,7 @@ myIso.setValue(126, customField, messageFactory.getCustomField(126), IsoType.LLL
 j8583 cannot perform this copy operation for you: even though the `MessageFactory` can detect if
 your custom class implements `Cloneable`, it can't invoke the `clone()` method because it's
 protected, and there's no guarantee that your implementation made it public.
+
+---
+
+← Previous: [XML configuration](xml-configuration.md) | 🏠 [Documentation home](README.md) | Next: [Spring integration](spring-integration.md) →

--- a/docs/iso8583-protocol.md
+++ b/docs/iso8583-protocol.md
@@ -1,5 +1,7 @@
 # What is ISO 8583?
 
+[🏠 Documentation home](README.md)
+
 ISO 8583 is a message format used for credit card transactions, banking and other commercial
 interactions between different systems. It has an ASCII variant and a binary one, and it is
 somewhat convoluted and difficult to implement.
@@ -165,3 +167,7 @@ the message type), the bitmap is not hex-encoded so it's only 8 bytes long, and 
 You can encode messages in binary by setting the `binaryHeader`/`binaryFields` properties on an
 `IsoMessage`, or on the `MessageFactory` directly so they get passed to all new messages. They
 must be set on the `MessageFactory` if you want it to parse binary messages.
+
+---
+
+🏠 [Documentation home](README.md) | Next: [Usage guide](usage-guide.md) →

--- a/docs/polyglot-compatibility.md
+++ b/docs/polyglot-compatibility.md
@@ -1,5 +1,7 @@
 # Groovy and Scala compatibility
 
+[🏠 Documentation home](README.md)
+
 j8583 is a plain Java library, so it's compatible with any JVM language, including Groovy and
 Scala. Beyond that, a few j8583 classes have extra methods specifically to give a nicer,
 shorthand syntax in those languages.
@@ -66,3 +68,7 @@ message.setField(4, IsoType.AMOUNT(amount))
     .setField(7, IsoType.DATE10(new Date()))
     .setField(11, IsoType.NUMERIC(trace, 6))
 ```
+
+---
+
+← Previous: [Spring integration](spring-integration.md) | 🏠 [Documentation home](README.md) | Next: [Simple message parser](simple-parser.md) →

--- a/docs/simple-parser.md
+++ b/docs/simple-parser.md
@@ -1,5 +1,7 @@
 # Simple message parser
 
+[🏠 Documentation home](README.md)
+
 The j8583 jar contains a small command-line program to parse ISO 8583 messages, using a
 configuration file specified on the command line.
 
@@ -18,3 +20,7 @@ default configuration file found on the classpath (see `ConfigParser.configureFr
 You can then paste an ISO 8583 message encoded as text, without any ISO header, and the program
 will parse it, showing the message type and, for each field present in the message, its number,
 type, length and value.
+
+---
+
+← Previous: [Groovy and Scala compatibility](polyglot-compatibility.md) | 🏠 [Documentation home](README.md)

--- a/docs/spring-integration.md
+++ b/docs/spring-integration.md
@@ -1,5 +1,7 @@
 # Spring integration
 
+[🏠 Documentation home](README.md)
+
 You can configure a `MessageFactory` as a bean in a Spring `ApplicationContext`, and inject it
 into any other components that need to create or parse `IsoMessage`s. j8583 has no dependency on
 Spring itself — `MessageFactory` is a plain Java bean, so it works with Spring's standard XML or
@@ -56,3 +58,7 @@ after retrieving the bean (or in a factory method / `@PostConstruct`):
 | `timezoneForParseGuide` | Sets the timezone for a specific field of a specific message type. Useful if you need to encode/decode dates with a timezone other than the local one. |
 | `customField` | Sets a single `CustomField` encoder for one field. |
 | `isoHeader` | Sets the ISO header to use for a specific message type. |
+
+---
+
+← Previous: [Custom field encoders](custom-field-encoders.md) | 🏠 [Documentation home](README.md) | Next: [Groovy and Scala compatibility](polyglot-compatibility.md) →

--- a/docs/usage-guide.md
+++ b/docs/usage-guide.md
@@ -1,5 +1,7 @@
 # Usage guide
 
+[🏠 Documentation home](README.md)
+
 This guide explains how to set up j8583. If you want to know more about the ISO 8583 protocol
 itself, read [What is ISO 8583?](iso8583-protocol.md) first.
 
@@ -149,3 +151,7 @@ production or against real cardholder data.
 
 The easiest way to configure message templates and parsing templates is by using an
 [XML config file](xml-configuration.md) and passing it to the `MessageFactory`.
+
+---
+
+← Previous: [What is ISO 8583?](iso8583-protocol.md) | 🏠 [Documentation home](README.md) | Next: [XML configuration](xml-configuration.md) →

--- a/docs/xml-configuration.md
+++ b/docs/xml-configuration.md
@@ -1,5 +1,7 @@
 # XML configuration
 
+[🏠 Documentation home](README.md)
+
 The `MessageFactory` can read an XML file to set up message templates, ISO headers by type, and
 parsing templates — the most cumbersome parts to configure programmatically.
 
@@ -159,3 +161,7 @@ message.setValue(125, f, f, IsoType.LLLVAR, 0);
 ```
 
 When the message is encoded, field 125 will be `018one  03two000123OK`.
+
+---
+
+← Previous: [Usage guide](usage-guide.md) | 🏠 [Documentation home](README.md) | Next: [Custom field encoders](custom-field-encoders.md) →


### PR DESCRIPTION
Each guide page now has a "Documentation home" breadcrumb at the top
and a Previous/Home/Next footer at the bottom, following the reading
order already listed in docs/README.md. docs/README.md itself links
back to the root README.md. All links are relative so they work
directly on GitHub without a docs framework.